### PR TITLE
Fixed wso2/product-iots#1524

### DIFF
--- a/iOSMDMAgent.xcodeproj/project.pbxproj
+++ b/iOSMDMAgent.xcodeproj/project.pbxproj
@@ -252,7 +252,7 @@
 					14BD72271A83479800D43DE5 = {
 						CreatedOnToolsVersion = 6.1.1;
 						DevelopmentTeam = KED4SHKL8S;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -460,15 +460,16 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = iOSMDMAgent/iOSMDMAgent.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution: WSO2 Inc";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				DEVELOPMENT_TEAM = KED4SHKL8S;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = iOSMDMAgent/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wso2.carbon.emm.ios.agent;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "008bd780-edd6-4f7e-b5b4-6861209b4617";
-				PROVISIONING_PROFILE_SPECIFIER = "WSO2 EMM iOS Enterprise provision profile";
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -479,15 +480,16 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = iOSMDMAgent/iOSMDMAgent.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution: WSO2 Inc";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				DEVELOPMENT_TEAM = KED4SHKL8S;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = iOSMDMAgent/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wso2.carbon.emm.ios.agent;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "008bd780-edd6-4f7e-b5b4-6861209b4617";
-				PROVISIONING_PROFILE_SPECIFIER = "WSO2 EMM iOS Enterprise provision profile";
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/iOSMDMAgent/AppDelegate.h
+++ b/iOSMDMAgent/AppDelegate.h
@@ -20,6 +20,7 @@
 @property (strong, nonatomic) AVAudioPlayer *theAudio;
 
 - (void)showLoginViewController;
+- (void)authorizeLocationService;
 
 @end
 

--- a/iOSMDMAgent/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/iOSMDMAgent/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -101,6 +101,11 @@
       "idiom" : "ipad",
       "filename" : "Icon-App-83.5x83.5@2x.png",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/iOSMDMAgent/Info.plist
+++ b/iOSMDMAgent/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>GA</string>
+	<string>Alpha</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -38,7 +38,11 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This allows WSO2 IoT Server to retrieve your device's updated location details </string>
 	<key>NSLocationAlwaysUsageDescription</key>
+	<string>This allows WSO2 IoT Server to retrieve your device's updated location details </string>
+	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This allows WSO2 IoT Server to retrieve your device's updated location details </string>
 	<key>UIBackgroundModes</key>
 	<array>


### PR DESCRIPTION
## Purpose
> Apple has recently introduced new updates to the device location service with their iOS 11 release. These changes are getting affected to WSO2 iOS agent, hence it is necessary to update the agent with the relevant configurations. Due to this update, even though the enrolment of an iOS device is getting success, device location cannot be retrieved.

## Approach
> Went through the latest Apple documentation and added new methods to comply with new location authorization service.

## User stories
> This fix has introduced a new user story. When a user decides to change the location authorization from the settings app, it get's affected to the application's location retrieval process. Therefore, a new dialog box is introduced to turn on location services if it is disabled.

![img_2740](https://user-images.githubusercontent.com/11870191/33956002-5b2a89dc-e063-11e7-85c9-b4038e838442.PNG)
![img_2739](https://user-images.githubusercontent.com/11870191/33956028-66d7ebd0-e063-11e7-8ecb-9d7ba699f4f0.PNG)
