### PR TITLE
Changed the agent to compatible with the fix for wso2/product-iots#15…

### DIFF
--- a/iOSMDMAgent/AppDelegate.m
+++ b/iOSMDMAgent/AppDelegate.m
@@ -168,6 +168,10 @@
     
     [self registerForPushToken];
     [MDMUtils setEnrollStatus:ENROLLED];
+    NSLog(@"handleOpenURL:Enforcing effective policy");
+    ConnectionUtils *connectionUtils = [[ConnectionUtils alloc] init];
+    connectionUtils.delegate = self;
+    [connectionUtils enforceEffectivePolicy:[MDMUtils getDeviceUDID]];
     return YES;
 }
 

--- a/iOSMDMAgent/ConnectionUtils.h
+++ b/iOSMDMAgent/ConnectionUtils.h
@@ -14,5 +14,6 @@
 - (void)sendLocationToServer:(NSString *)udid latitiude:(float)lat longitude:(float)longi;
 - (void)sendUnenrollToServer;
 - (void)sendOperationUpdateToServer:(NSString *)deviceId operationId:(NSString *)opId status:(NSString *)state;
+- (void)enforceEffectivePolicy:(NSString *)deviceId;
 
 @end

--- a/iOSMDMAgent/Endpoints.plist
+++ b/iOSMDMAgent/Endpoints.plist
@@ -15,7 +15,7 @@
 	<key>LOCATION_PUBLISH_URI</key>
 	<string>/devices/location/%@</string>
 	<key>ENROLLMENT_URI</key>
-	<string>/ios-web-agent/enrollments/ios/login-agent</string>
+	<string>/ios-web-agent/enrollments/ios/login-agent?isAgentAvailable=true</string>
 	<key>API_PORT</key>
 	<string>8243</string>
 	<key>ENROLMENT_PORT</key>
@@ -24,5 +24,7 @@
 	<string></string>
 	<key>SERVER_URL</key>
 	<string>https://gateway.api.cloudstaging.wso2.com</string>
+	<key>EFFECTIVE_POLICY_PATH</key>
+	<string>/devices/effective-policy/%@</string>
 </dict>
 </plist>

--- a/iOSMDMAgent/URLUtils.h
+++ b/iOSMDMAgent/URLUtils.h
@@ -40,6 +40,7 @@ extern NSString *const OPERATION_ID_RESPOSNE;
 extern NSString *const STATUS;
 extern int OAUTH_FAIL_CODE;
 extern NSString *const ENROLLMENT_URL;
+extern NSString *const EFFECTIVE_POLICY_PATH;
 
 + (void)saveServerURL:(NSString *)serverURL;
 + (NSString *)getServerURL;
@@ -55,6 +56,6 @@ extern NSString *const ENROLLMENT_URL;
 + (NSString *)getSavedEnrollmentURL;
 + (NSString *)getEnrollmentURLFromPlist;
 + (NSString *)getServerURLFromPlist;
-
++ (NSString *)getEffectivePolicyURL;
 
 @end

--- a/iOSMDMAgent/URLUtils.m
+++ b/iOSMDMAgent/URLUtils.m
@@ -42,6 +42,7 @@ NSString *const FORM_ENCODED = @"application/x-www-form-urlencoded";
 NSString *const OPERATION_ID_RESPOSNE = @"operationId";
 NSString *const STATUS = @"status";
 NSString *const ENROLLMENT_URL = @"ENROLLMENT_URL";
+NSString *const EFFECTIVE_POLICY_PATH = @"EFFECTIVE_POLICY_PATH";
 
 
 + (NSDictionary *)readEndpoints {
@@ -113,6 +114,10 @@ NSString *const ENROLLMENT_URL = @"ENROLLMENT_URL";
 
 + (NSString *)getEnrollmentURL {
     return [NSString stringWithFormat:@"%@:%@%@", [URLUtils getSavedEnrollmentURL], [URLUtils getEnrolmentPort], [[URLUtils readEndpoints] objectForKey:ENROLLMENT_URI]];
+}
+
++ (NSString *)getEffectivePolicyURL {
+    return [NSString stringWithFormat:@"%@:%@%@%@", [URLUtils getServerURL], [URLUtils getAPIPort], [URLUtils getContextURL], [[URLUtils readEndpoints] objectForKey:EFFECTIVE_POLICY_PATH]];
 }
 
 @end


### PR DESCRIPTION
## Purpose
> At the enrollment, after the profile is installed, the iOS enrollment flow calls the /checkin endpoint and in this endpoint, there is a call to apply effective policy.(policyUtils.enforceEffectivePolicy) and this puts a policy operation and this policy contains disable safari. This happens extremely fast and after the profile is installed the user will click done button which will open up safari. However, at this point the policy is already applied on the device and safari is disabled. Therefore safari will disappear and the tokens will not be passed to the agent which happens at the last screen of the enrollment process through safari.

## Approach
> Passed a variable at the login page just to identify whether this request is coming from agent app or the browser itself (to support enrolment without the agent). Once it is identified, it will be sent to the backend and store as a property. Then this property will be checked during the "check-in" request before enforcing the effective policy. So if this request is coming from the agent, the effective policy will not get applied immediately. Once the enrolment is finished and the agent app is launched, from there, get effective policy API is invoked to enforce the policy.