### PR TITLE
Fixing agent not unenrolling and embed the server URL

### DIFF
--- a/iOSMDMAgent/AppDelegate.m
+++ b/iOSMDMAgent/AppDelegate.m
@@ -39,7 +39,7 @@
     [self authorizeLocationService];
     
     NSString *enrollURL = [URLUtils getEnrollmentURLFromPlist];
-    NSString *serverURL = [URLUtils getEnrollmentURLFromPlist];
+    NSString *serverURL = [URLUtils getServerURLFromPlist];
     if(enrollURL && ![@"" isEqualToString:enrollURL] && serverURL && ![@"" isEqualToString:serverURL]) {
         NSLog(@"Reading server url from plist");
         [URLUtils saveServerURL:serverURL];

--- a/iOSMDMAgent/AppDelegate.m
+++ b/iOSMDMAgent/AppDelegate.m
@@ -44,7 +44,7 @@
         NSLog(@"Reading server url from plist");
         [URLUtils saveServerURL:serverURL];
         [URLUtils saveEnrollmentURL:enrollURL];
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[URLUtils getEnrollmentURL]]];
+        //[[UIApplication sharedApplication] openURL:[NSURL URLWithString:[URLUtils getEnrollmentURL]]];
     }
  
     return YES;

--- a/iOSMDMAgent/AppDelegate.m
+++ b/iOSMDMAgent/AppDelegate.m
@@ -44,7 +44,6 @@
         NSLog(@"Reading server url from plist");
         [URLUtils saveServerURL:serverURL];
         [URLUtils saveEnrollmentURL:enrollURL];
-        //[[UIApplication sharedApplication] openURL:[NSURL URLWithString:[URLUtils getEnrollmentURL]]];
     }
  
     return YES;

--- a/iOSMDMAgent/ConnectionUtils.m
+++ b/iOSMDMAgent/ConnectionUtils.m
@@ -154,7 +154,7 @@
 }
 
 - (void)sendUnenrollToServer {
-    //[self getNewAccessToken];
+    [self getNewAccessToken];
     NSURL *url = [NSURL URLWithString:[URLUtils getUnenrollURL]];
 
     NSString *deviceId = [MDMUtils getDeviceUDID];

--- a/iOSMDMAgent/ConnectionUtils.m
+++ b/iOSMDMAgent/ConnectionUtils.m
@@ -154,7 +154,7 @@
 }
 
 - (void)sendUnenrollToServer {
-    [self getNewAccessToken];
+    //[self getNewAccessToken];
     NSURL *url = [NSURL URLWithString:[URLUtils getUnenrollURL]];
 
     NSString *deviceId = [MDMUtils getDeviceUDID];

--- a/iOSMDMAgent/LoginViewController.m
+++ b/iOSMDMAgent/LoginViewController.m
@@ -19,7 +19,7 @@
     self.txtServer.delegate = self;
     // Do any additional setup after loading the view.
     NSString *enrollURL = [URLUtils getEnrollmentURLFromPlist];
-    NSString *serverURL = [URLUtils getEnrollmentURLFromPlist];
+    NSString *serverURL = [URLUtils getServerURLFromPlist];
     if(enrollURL && ![@"" isEqualToString:enrollURL] && serverURL && ![@"" isEqualToString:serverURL]) {
         [self.txtServer setText:serverURL];
     }
@@ -73,7 +73,7 @@
          Where the URLs are hard coded.
         */
         NSString *enrollURL = [URLUtils getEnrollmentURLFromPlist];
-        NSString *serverURL = [URLUtils getEnrollmentURLFromPlist];
+        NSString *serverURL = [URLUtils getServerURLFromPlist];
         if(enrollURL && ![@"" isEqualToString:enrollURL] && serverURL && ![@"" isEqualToString:serverURL]) {
             [URLUtils saveServerURL:serverURL];
             [URLUtils saveEnrollmentURL:enrollURL];

--- a/iOSMDMAgent/LoginViewController.m
+++ b/iOSMDMAgent/LoginViewController.m
@@ -18,6 +18,11 @@
     [super viewDidLoad];
     self.txtServer.delegate = self;
     // Do any additional setup after loading the view.
+    NSString *enrollURL = [URLUtils getEnrollmentURLFromPlist];
+    NSString *serverURL = [URLUtils getEnrollmentURLFromPlist];
+    if(enrollURL && ![@"" isEqualToString:enrollURL] && serverURL && ![@"" isEqualToString:serverURL]) {
+        [self.txtServer setText:serverURL];
+    }
 }
 
 - (void)didReceiveMemoryWarning {
@@ -67,8 +72,15 @@
          taken as the same. Check didChangeAuthorizationStatus method in AppDeligate.m for production behaviour,
          Where the URLs are hard coded.
         */
-        [URLUtils saveServerURL:self.txtServer.text];
-        [URLUtils saveEnrollmentURL:self.txtServer.text];
+        NSString *enrollURL = [URLUtils getEnrollmentURLFromPlist];
+        NSString *serverURL = [URLUtils getEnrollmentURLFromPlist];
+        if(enrollURL && ![@"" isEqualToString:enrollURL] && serverURL && ![@"" isEqualToString:serverURL]) {
+            [URLUtils saveServerURL:serverURL];
+            [URLUtils saveEnrollmentURL:enrollURL];
+        } else {
+            [URLUtils saveServerURL:self.txtServer.text];
+            [URLUtils saveEnrollmentURL:self.txtServer.text];
+        }
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[URLUtils getEnrollmentURL]]];
     }
 }


### PR DESCRIPTION
## Purpose
Fixes the unenrollment not working in the iOS agent and adds the ability to embed the server URL to agent
https://github.com/wso2/cdmf-agent-ios/issues/14
https://github.com/wso2/cdmf-agent-ios/issues/15

## Goals
Currety the agent unenroll button produces an error and does not unenroll and this is fixed.

## Approach
Removed the unwanted backend call  to token endpoint
Embedded the Enrollment URL to the agent

## Test environment
IoT 3.1.0 and iOS agent
 