### PR TITLE
Operations are not completed when refresh tokens expire

### DIFF
--- a/iOSMDMAgent/AppDelegate.m
+++ b/iOSMDMAgent/AppDelegate.m
@@ -138,8 +138,8 @@
     NSString *refreshToken;
     NSString *clientCredentials;
     NSString *tenantDomain;
-    NSString *udid = [[url host] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    [MDMUtils saveDeviceUDID:udid];
+    NSString *isRefreshComplete;
+
     NSArray *queryParams = [[url query] componentsSeparatedByString:@"&"];
     for (int i=0; i< [queryParams count]; i++){
         NSArray *keyValue = [queryParams[i] componentsSeparatedByString:@"="];
@@ -157,6 +157,9 @@
         else if ([key isEqualToString:@"tenantDomain"]) {
             tenantDomain = value;
         }
+        else if ([key isEqualToString:@"isRefreshComplete"]) {
+            isRefreshComplete = value;
+        }
     }
     
 
@@ -164,13 +167,17 @@
     [MDMUtils savePreferance:REFRESH_TOKEN value:refreshToken];
     [MDMUtils savePreferance:CLIENT_CREDENTIALS value:clientCredentials];
 
-    
-    [self registerForPushToken];
-    [MDMUtils setEnrollStatus:ENROLLED];
-    NSLog(@"handleOpenURL:Enforcing effective policy");
-    ConnectionUtils *connectionUtils = [[ConnectionUtils alloc] init];
-    connectionUtils.delegate = self;
-    [connectionUtils enforceEffectivePolicy:[MDMUtils getDeviceUDID]];
+    if (!isRefreshComplete) {
+        NSLog(@"New enrollment");
+        NSString *udid = [[url host] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        [MDMUtils saveDeviceUDID:udid];
+        [self registerForPushToken];
+        [MDMUtils setEnrollStatus:ENROLLED];
+        NSLog(@"handleOpenURL:Enforcing effective policy");
+        ConnectionUtils *connectionUtils = [[ConnectionUtils alloc] init];
+        connectionUtils.delegate = self;
+        [connectionUtils enforceEffectivePolicy:[MDMUtils getDeviceUDID]];
+    }
     return YES;
 }
 

--- a/iOSMDMAgent/ConnectionUtils.m
+++ b/iOSMDMAgent/ConnectionUtils.m
@@ -6,6 +6,7 @@
 #import "ConnectionUtils.h"
 #import "URLUtils.h"
 #import "MDMUtils.h"
+#import "AppDelegate.h"
 
 //Remove this code chunk in production
 @interface NSURLRequest(Private)
@@ -239,10 +240,10 @@
     NSData * data = [NSURLConnection sendSynchronousRequest:request
                                           returningResponse:&response
                                                       error:&error];
+    long code = [(NSHTTPURLResponse *)response statusCode];
     
     if (error == nil)
     {
-        long code = [(NSHTTPURLResponse *)response statusCode];
         NSLog(@"getNewAccessToken:Response recieved: %li", code);
         if (code == HTTP_OK) {
             NSError *jsonError;
@@ -259,6 +260,10 @@
 
             return true;
         }
+    }
+    if (code == HTTP_BAD_REQUEST) {
+        NSLog(@"Refresh token expired.");
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[URLUtils getTokenRefreshURL]]];
     }
     NSLog(@"Error while getting refresh token.");
     return false;

--- a/iOSMDMAgent/Endpoints.plist
+++ b/iOSMDMAgent/Endpoints.plist
@@ -26,5 +26,7 @@
 	<string>https://gateway.api.cloudstaging.wso2.com</string>
 	<key>EFFECTIVE_POLICY_PATH</key>
 	<string>/devices/effective-policy/%@</string>
+	<key>TOKEN_REFRESH_URI</key>
+	<string>/ios-web-agent/enrollments/ios/login-agent?isRefresh=true</string>
 </dict>
 </plist>

--- a/iOSMDMAgent/URLUtils.h
+++ b/iOSMDMAgent/URLUtils.h
@@ -11,6 +11,7 @@
 extern float const HTTP_REQUEST_TIME;
 extern int HTTP_OK;
 extern int HTTP_CREATED;
+extern int HTTP_BAD_REQUEST;
 extern NSString *const ENDPOINT_FILE_NAME;
 extern NSString *const EXTENSION;
 extern NSString *const TOKEN_PUBLISH_URI;
@@ -57,5 +58,6 @@ extern NSString *const EFFECTIVE_POLICY_PATH;
 + (NSString *)getEnrollmentURLFromPlist;
 + (NSString *)getServerURLFromPlist;
 + (NSString *)getEffectivePolicyURL;
++ (NSString *)getTokenRefreshURL;
 
 @end

--- a/iOSMDMAgent/URLUtils.m
+++ b/iOSMDMAgent/URLUtils.m
@@ -11,6 +11,7 @@ float const HTTP_REQUEST_TIME = 60.0f;
 int HTTP_OK = 200;
 int HTTP_CREATED = 201;
 int OAUTH_FAIL_CODE = 401;
+int HTTP_BAD_REQUEST = 400;
 NSString *const ENDPOINT_FILE_NAME = @"Endpoints";
 NSString *const EXTENSION = @"plist";
 NSString *const TOKEN_PUBLISH_URI = @"TOKEN_PUBLISH_URI";
@@ -43,6 +44,7 @@ NSString *const OPERATION_ID_RESPOSNE = @"operationId";
 NSString *const STATUS = @"status";
 NSString *const ENROLLMENT_URL = @"ENROLLMENT_URL";
 NSString *const EFFECTIVE_POLICY_PATH = @"EFFECTIVE_POLICY_PATH";
+NSString *const TOKEN_REFRESH_URI = @"TOKEN_REFRESH_URI";
 
 
 + (NSDictionary *)readEndpoints {
@@ -114,6 +116,10 @@ NSString *const EFFECTIVE_POLICY_PATH = @"EFFECTIVE_POLICY_PATH";
 
 + (NSString *)getEnrollmentURL {
     return [NSString stringWithFormat:@"%@:%@%@", [URLUtils getSavedEnrollmentURL], [URLUtils getEnrolmentPort], [[URLUtils readEndpoints] objectForKey:ENROLLMENT_URI]];
+}
+
++ (NSString *)getTokenRefreshURL {
+    return [NSString stringWithFormat:@"%@:%@%@", [URLUtils getSavedEnrollmentURL], [URLUtils getEnrolmentPort], [[URLUtils readEndpoints] objectForKey:TOKEN_REFRESH_URI]];
 }
 
 + (NSString *)getEffectivePolicyURL {


### PR DESCRIPTION
## Purpose
When refresh token expires, the token must be refreshed by authenticating the user in the iOS agent
Fixes https://github.com/wso2/product-iots/issues/1598

## Goals
When the refresh token in the client expires, although the APNS messages are received to the agent, the response is not sent back to the server.

## Approach
Login UI is prompted, for the user to relogin and refresh the tokens.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
iOS 11
 
## Learning
N/A