### PR TITLE
Fixing ring not working when device is muted

### DIFF
--- a/iOSMDMAgent/AppDelegate.m
+++ b/iOSMDMAgent/AppDelegate.m
@@ -8,6 +8,7 @@
 #import "ConnectionUtils.h"
 #import "ConnectionUtils.h"
 #import "URLUtils.h"
+#import <MediaPlayer/MediaPlayer.h>
 
 #define systemSoundID    1154
 
@@ -276,16 +277,29 @@
     NSString *soundPath =[[NSBundle mainBundle] pathForResource:SOUND_FILE_NAME ofType:SOUND_FILE_EXTENSION];
     NSURL *soundURL = [NSURL fileURLWithPath:soundPath];
     
+    /**
+     * iOS does not natively provide a way to update volume of a devices without users consent.
+     * Since MPMusicPlayerController.volume is depricated, we have to use the following
+     * work around, where we create a volume slider and adjust the volume.
+     */
+    MPVolumeView* mpVolumeView = [[MPVolumeView alloc] init];
+    UISlider* volumeSlider = nil;
+    for (UIView *view in [mpVolumeView subviews]){
+        if ([view.class.description isEqualToString:@"MPVolumeSlider"]){
+            volumeSlider = (UISlider*)view;
+            break;
+        }
+    }
+    [volumeSlider setValue:1.0f animated:YES];
+    [volumeSlider sendActionsForControlEvents:UIControlEventTouchUpInside];
+
     NSError *error = nil;
     self.theAudio = [[AVAudioPlayer alloc] initWithContentsOfURL:soundURL error:&error];
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback withOptions:AVAudioSessionCategoryOptionMixWithOthers error:nil];
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback
+                                     withOptions:AVAudioSessionCategoryOptionMixWithOthers error:nil];
     [[AVAudioSession sharedInstance] setActive: YES error: nil];
     [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
     [self.theAudio play];
-//    // declared system sound here
-//    
-//    // to play sound
-//    AudioServicesPlaySystemSound (systemSoundID);
 
 }
 


### PR DESCRIPTION
## Purpose
When the ring operation is added to the device and if the devices volume is muted, the ring sound is not audible.
Fixed wso2/product-iots#1668

## Goals
Get ring to work when the agent is muted

## Approach
 Although the ringer volume is at maximum, since AVAudioPlayer is used for audio playing, the ringer volume has no effect. Since MPMusicPlayerController.volume is depricated, we have to use the work around, where we create a volume slider and adjust the volume.

## User stories
N/A

## Release note
Ring operation is made to work when the device is muted

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
MacOS 10.1, iOS 11.2.1
 
## Learning
N/A