### PR TITLE
Adding DEP auto enroll and configure ability

### DIFF
--- a/iOSMDMAgent.xcodeproj/project.pbxproj
+++ b/iOSMDMAgent.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		14BD723C1A83479900D43DE5 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 14BD723A1A83479900D43DE5 /* LaunchScreen.xib */; };
 		14BD72481A83479900D43DE5 /* iOSMDMAgentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 14BD72471A83479900D43DE5 /* iOSMDMAgentTests.m */; };
 		14BD72541A834E2200D43DE5 /* LoginViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 14BD72531A834E2200D43DE5 /* LoginViewController.m */; };
+		E80C7E3C2040137100215441 /* ManagedAppConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = E80C7E3B2040137100215441 /* ManagedAppConfig.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,7 @@
 		14BD72521A834E2200D43DE5 /* LoginViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoginViewController.h; sourceTree = "<group>"; };
 		14BD72531A834E2200D43DE5 /* LoginViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoginViewController.m; sourceTree = "<group>"; };
 		40735CED1D9BC4CA00AAB802 /* iOSMDMAgent.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = iOSMDMAgent.entitlements; sourceTree = "<group>"; };
+		E80C7E3B2040137100215441 /* ManagedAppConfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = ManagedAppConfig.plist; path = ManagedAppConfig.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -142,6 +144,7 @@
 		14BD722A1A83479800D43DE5 /* iOSMDMAgent */ = {
 			isa = PBXGroup;
 			children = (
+				E80C7E3B2040137100215441 /* ManagedAppConfig.plist */,
 				40735CED1D9BC4CA00AAB802 /* iOSMDMAgent.entitlements */,
 				142143931A96009B006C34B6 /* SDK */,
 				14BD722F1A83479900D43DE5 /* AppDelegate.h */,
@@ -298,6 +301,7 @@
 			files = (
 				14BD72371A83479900D43DE5 /* Main.storyboard in Resources */,
 				14AE5F5E1AC03509005144D3 /* Endpoints.plist in Resources */,
+				E80C7E3C2040137100215441 /* ManagedAppConfig.plist in Resources */,
 				144CAA821AC2B96D006AB191 /* sound.caf in Resources */,
 				14BD723C1A83479900D43DE5 /* LaunchScreen.xib in Resources */,
 				14BD72391A83479900D43DE5 /* Images.xcassets in Resources */,

--- a/iOSMDMAgent/ConnectionUtils.m
+++ b/iOSMDMAgent/ConnectionUtils.m
@@ -23,7 +23,7 @@
 
     NSURL *url = [NSURL URLWithString:endpoint];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:HTTP_REQUEST_TIME];
-    
+    NSLog(@"sendPushTokenToServer:url: %@", url);
     NSMutableDictionary *paramDictionary = [[NSMutableDictionary alloc] init];
     [paramDictionary setValue:token forKey:TOKEN];
 
@@ -55,6 +55,7 @@
 - (void)enforceEffectivePolicy:(NSString *)deviceId {
     
     NSString *endpoint = [NSString stringWithFormat:[URLUtils getEffectivePolicyURL], deviceId];
+    NSLog(@"enforceEffectivePolicy:endpoint: %@", endpoint);
     
     NSURL *url = [NSURL URLWithString:endpoint];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:HTTP_REQUEST_TIME];

--- a/iOSMDMAgent/ManagedAppConfig.plist
+++ b/iOSMDMAgent/ManagedAppConfig.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>enrollmentURL</key>
+	<string></string>
+	<key>serverURL</key>
+	<string></string>
+	<key>UDID</key>
+	<string></string>
+	<key>clientSecret</key>
+	<string></string>
+	<key>clientId</key>
+	<string></string>
+	<key>accessToken</key>
+	<string></string>
+	<key>refreshToken</key>
+	<string></string>
+	<key>depEnabled</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
In order to remotely push and configure iOS agent, Apple's managed app configurations needs to be implemented. This provides the ability to listen to remote configurations and auto enroll the agent. https://developer.apple.com/library/content/samplecode/sc2279/Introduction/Intro.html

Fixed - https://github.com/wso2/product-iots/issues/1738

## Purpose
Adding DEP auto enroll and configure ability

## Goals
Adding DEP auto enroll and configure ability.

## Approach
Implemented Apple's managed app configurations, https://developer.apple.com/library/content/samplecode/sc2279/Introduction/Intro.html

## User stories
N/A

## Release note
Added DEP auto enroll and configure ability

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
 - Integration tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8, iOS 11.2.1
 
## Learning
https://developer.apple.com/library/content/samplecode/sc2279/Introduction/Intro.html